### PR TITLE
missing WANDB_ENTITY env var prompts WANDB_API_KEY

### DIFF
--- a/lightning_hpo/loggers.py
+++ b/lightning_hpo/loggers.py
@@ -16,7 +16,7 @@ class WandbConfig(BaseLogger):
     @staticmethod
     def validate():
         if os.getenv("WANDB_ENTITY") is None:
-            raise Exception("Please, use lightning run app ... --env WANDB_API_KEY=X")
+            raise Exception("Please, use lightning run app ... --env WANDB_ENTITY=X")
         if os.getenv("WANDB_API_KEY") is None:
             raise Exception("Please, use lightning run app ... --env WANDB_API_KEY=X")
 


### PR DESCRIPTION
	modified:   lightning_hpo/loggers.py

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?

Missing WANDB_ENTITY env var wrongly prompts WANDB_API_KEY.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
